### PR TITLE
再接続時の重複セッションを解消し手動位置判定を追加

### DIFF
--- a/v4/ws/racing/auth.go
+++ b/v4/ws/racing/auth.go
@@ -26,6 +26,7 @@ func (c *Client) auth(msg *AuthInfo) {
 	if ok := auth.VerifyJWT(msg.Token); !ok {
 		log.Println("Unauthorized:", c.ID)
 		c.sendFailedAuthMsg()
+
 		c.Hub.Unregister <- c
 
 		return
@@ -34,6 +35,7 @@ func (c *Client) auth(msg *AuthInfo) {
 	if !isValidRole(msg.Role) {
 		log.Println("Invalid role:", c.ID)
 		c.sendFailedAuthMsg()
+
 		c.Hub.Unregister <- c
 
 		return
@@ -41,6 +43,7 @@ func (c *Client) auth(msg *AuthInfo) {
 
 	if msg.Role == MarkRole && msg.MarkNo == 0 {
 		log.Println("Not selecting mark no:", c.ID)
+
 		c.Hub.Unregister <- c
 
 		return
@@ -48,7 +51,11 @@ func (c *Client) auth(msg *AuthInfo) {
 
 	// If the client has not linked yet, link it.
 	if oldID := c.Hub.findDisconnectedID(msg.UserID); oldID == "" {
-		c.link(msg.UserID, msg.Role, msg.MarkNo)
+		if activeID := c.Hub.findActiveID(msg.UserID, msg.Role, msg.MarkNo); activeID == "" {
+			c.link(msg.UserID, msg.Role, msg.MarkNo)
+		} else {
+			c.replaceActive(activeID, msg.UserID, msg.Role, msg.MarkNo)
+		}
 	} else {
 		c.restore(oldID, msg.MarkNo)
 	}
@@ -78,17 +85,7 @@ func (c *Client) link(userID string, role string, markNo int) {
 func (c *Client) restore(oldID string, markNo int) {
 	oldClient := c.Hub.Disconnectors[oldID]
 
-	// Switch data from old to new
-	c.UserID = oldClient.UserID
-	c.Role = oldClient.Role
-	c.NextMarkNo = oldClient.NextMarkNo
-	c.CourseLimit = oldClient.CourseLimit
-	c.Location = oldClient.Location
-	c.BatteryLevel = oldClient.BatteryLevel
-
-	if c.Role == MarkRole {
-		c.MarkNo = markNo
-	}
+	c.adoptState(oldClient, oldClient.UserID, oldClient.Role, markNo)
 
 	// Delete the old client instance
 	c.Hub.Unregister <- oldClient
@@ -100,6 +97,48 @@ func (c *Client) restore(oldID string, markNo int) {
 
 	// Send the authorize result message
 	c.sendRestoreAuthMsg()
+}
+
+func (c *Client) replaceActive(
+	oldID string,
+	userID string,
+	role string,
+	markNo int,
+) {
+	oldClient := c.Hub.Clients[oldID]
+	if oldClient == nil {
+		c.link(userID, role, markNo)
+		return
+	}
+
+	c.adoptState(oldClient, userID, role, markNo)
+
+	// Explicitly close and remove the duplicated active session.
+	c.Hub.Unregister <- oldClient
+
+	c.registerRoleGroup()
+
+	log.Printf("Replaced Active Session: %s <=> %s (%s)\n", c.ID, c.UserID, c.Role)
+
+	c.sendRestoreAuthMsg()
+}
+
+func (c *Client) adoptState(
+	oldClient *Client,
+	userID string,
+	role string,
+	markNo int,
+) {
+	c.UserID = userID
+	c.Role = role
+	c.NextMarkNo = oldClient.NextMarkNo
+	c.CourseLimit = oldClient.CourseLimit
+	c.Location = oldClient.Location
+	c.BatteryLevel = oldClient.BatteryLevel
+
+	if c.Role == MarkRole {
+		c.MarkNo = markNo
+	}
 }
 
 // registerRoleGroup registers the client to the role group.

--- a/v4/ws/racing/client.go
+++ b/v4/ws/racing/client.go
@@ -11,35 +11,38 @@ import (
 
 //nolint:mnd
 const (
-	AutoRoomingInterval = 30 * time.Second
-	ReadBufferByte      = 2048
-	WriteBufferByte     = 2048
-	WriteWait           = 10 * time.Second
-	PongWait            = 10 * time.Second
-	PingPeriod          = (PongWait * 9) / 10
-	MarkNum             = 3
-	MarkPosPeriod       = 5 * time.Second
-	NearSailPeriod      = 3 * time.Second
-	LivePeriod          = 1 * time.Second
-	MaxMessageByte      = 1024
-	NearRangeMeter      = 5.0
-	ClientIDLength      = 8
-	GuestUserIDLength   = 8
-	AthleteRoleID       = 0
-	MarkRoleID          = 1
-	ManagerRoleID       = 2
-	GuestRoleID         = 3
-	UnknownRoleID       = -1
-	AthleteRole         = "athlete"
-	MarkRole            = "mark"
-	ManagerRole         = "manager"
-	GuestRole           = "guest"
+	AutoRoomingInterval  = 30 * time.Second
+	ReadBufferByte       = 2048
+	WriteBufferByte      = 2048
+	WriteWait            = 10 * time.Second
+	PongWait             = 10 * time.Second
+	PingPeriod           = (PongWait * 9) / 10
+	MarkNum              = 3
+	MarkPosPeriod        = 5 * time.Second
+	NearSailPeriod       = 3 * time.Second
+	LivePeriod           = 1 * time.Second
+	MaxMessageByte       = 1024
+	NearRangeMeter       = 5.0
+	ClientIDLength       = 8
+	GuestUserIDLength    = 8
+	AthleteRoleID        = 0
+	MarkRoleID           = 1
+	ManagerRoleID        = 2
+	GuestRoleID          = 3
+	UnknownRoleID        = -1
+	AthleteRole          = "athlete"
+	MarkRole             = "mark"
+	ManagerRole          = "manager"
+	GuestRole            = "guest"
+	PositionSourceGPS    = "gps"
+	PositionSourceManual = "manual"
 )
 
 var ErrClosedChannel = errors.New("closed channel")
 
 type Client struct {
 	ID           string
+	ConnectedAt  time.Time
 	Hub          *Hub
 	Conn         *websocket.Conn
 	UserID       string
@@ -54,17 +57,19 @@ type Client struct {
 }
 
 type Position struct {
-	Lat float64 `json:"latitude"`
-	Lng float64 `json:"longitude"`
-	Acc float64 `json:"accuracy"`
+	Lat            float64 `json:"latitude"`
+	Lng            float64 `json:"longitude"`
+	Acc            float64 `json:"accuracy"`
+	PositionSource string  `json:"position_source,omitempty"`
 }
 
 type Location struct {
-	Lat           float64 `json:"latitude"`
-	Lng           float64 `json:"longitude"`
-	Acc           float64 `json:"accuracy"`
-	Heading       float64 `json:"heading"`
-	HeadingFixing float64 `json:"heading_fixing"`
+	Lat            float64 `json:"latitude"`
+	Lng            float64 `json:"longitude"`
+	Acc            float64 `json:"accuracy"`
+	Heading        float64 `json:"heading"`
+	HeadingFixing  float64 `json:"heading_fixing"`
+	PositionSource string  `json:"-"`
 }
 
 type Athlete struct {
@@ -86,6 +91,7 @@ type Mark struct {
 func NewClient(assocID string, conn *websocket.Conn) *Client {
 	return &Client{
 		ID:           utils.RandString(ClientIDLength),
+		ConnectedAt:  time.Now(),
 		Hub:          rooms[assocID],
 		Conn:         conn,
 		UserID:       "",
@@ -97,6 +103,18 @@ func NewClient(assocID string, conn *websocket.Conn) *Client {
 		BatteryLevel: -1,
 		Send:         make(chan []byte),
 	}
+}
+
+func isNewerClient(candidate *Client, current *Client) bool {
+	if current == nil {
+		return true
+	}
+
+	if candidate.ConnectedAt.Equal(current.ConnectedAt) {
+		return candidate.ID > current.ID
+	}
+
+	return candidate.ConnectedAt.After(current.ConnectedAt)
 }
 
 // getNearSail returns the sail that is near to the client.

--- a/v4/ws/racing/handler.go
+++ b/v4/ws/racing/handler.go
@@ -48,9 +48,10 @@ func Handler(c *gin.Context) {
 // receivePos receives the position from the client.
 func (c *Client) receivePos(msg *Position) {
 	c.Location = Location{
-		Lat: msg.Lat,
-		Lng: msg.Lng,
-		Acc: msg.Acc,
+		Lat:            msg.Lat,
+		Lng:            msg.Lng,
+		Acc:            msg.Acc,
+		PositionSource: msg.PositionSource,
 	}
 	//nolint:errcheck
 	go c.Hub.Logger.logLocation(c)

--- a/v4/ws/racing/hub.go
+++ b/v4/ws/racing/hub.go
@@ -66,7 +66,10 @@ func (h *Hub) registerEvent(c *Client) {
 // disconnectEvent disconnects the client.
 func (h *Hub) disconnectEvent(c *Client) {
 	log.Println("Disconnected:", c.ID)
-	c.Conn.Close()
+
+	if c.Conn != nil {
+		c.Conn.Close()
+	}
 
 	// Register the client to the disconnector group
 	h.Disconnectors[c.ID] = c
@@ -81,7 +84,10 @@ func (h *Hub) disconnectEvent(c *Client) {
 // unregisterEvent unregisters the client.
 func (h *Hub) unregisterEvent(c *Client) {
 	log.Println("Unregistered:", c.ID)
-	c.Conn.Close()
+
+	if c.Conn != nil {
+		c.Conn.Close()
+	}
 
 	delete(c.Hub.Clients, c.ID)
 	delete(c.Hub.Athletes, c.ID)
@@ -107,22 +113,24 @@ func metamorphoseMarks(marks map[string]*Client, idDeleted string) {
 
 // getAthleteInfos returns the athlete infos.
 func (h *Hub) getAthleteInfos() []Athlete {
-	athletes := []Athlete{}
-	existingUserIDs := map[string]bool{}
+	latestByUserID := map[string]*Client{}
 
 	for _, c := range h.Athletes {
-		// まだそのUserIDが挿入されていない場合のみ挿入
-		if !existingUserIDs[c.UserID] {
-			athletes = append(athletes, Athlete{
-				UserID:       c.UserID,
-				NextMarkNo:   c.NextMarkNo,
-				CourseLimit:  c.CourseLimit,
-				BatteryLevel: c.BatteryLevel,
-				CompassDeg:   c.CompassDeg,
-				Location:     c.Location,
-			})
-			existingUserIDs[c.UserID] = true
+		if isNewerClient(c, latestByUserID[c.UserID]) {
+			latestByUserID[c.UserID] = c
 		}
+	}
+
+	athletes := make([]Athlete, 0, len(latestByUserID))
+	for _, c := range latestByUserID {
+		athletes = append(athletes, Athlete{
+			UserID:       c.UserID,
+			NextMarkNo:   c.NextMarkNo,
+			CourseLimit:  c.CourseLimit,
+			BatteryLevel: c.BatteryLevel,
+			CompassDeg:   c.CompassDeg,
+			Location:     c.Location,
+		})
 	}
 
 	// Sort by user id asc
@@ -147,22 +155,32 @@ func getAthleteNo(userID string) int {
 // getMarkInfos returns the mark infos.
 func (h *Hub) getMarkInfos() []Mark {
 	marks := make([]Mark, h.MarkNum)
+	latestByMarkNo := make(map[int]*Client, h.MarkNum)
 
 	for _, c := range h.Marks {
 		if c.MarkNo > h.MarkNum {
 			panic("invalid mark no")
 		}
 
+		if isNewerClient(c, latestByMarkNo[c.MarkNo]) {
+			latestByMarkNo[c.MarkNo] = c
+		}
+	}
+
+	for markNo, c := range latestByMarkNo {
 		marks[c.MarkNo-1] = Mark{
 			UserID:       c.UserID,
 			MarkNo:       c.MarkNo,
 			BatteryLevel: c.BatteryLevel,
 			Position: Position{
-				Lat: c.Location.Lat,
-				Lng: c.Location.Lng,
-				Acc: c.Location.Acc,
+				Lat:            c.Location.Lat,
+				Lng:            c.Location.Lng,
+				Acc:            c.Location.Acc,
+				PositionSource: c.Location.PositionSource,
 			},
 		}
+
+		marks[markNo-1].MarkNo = markNo
 	}
 
 	for i := range marks {
@@ -217,11 +235,52 @@ func (h *Hub) findClientID(userID string) string {
 
 // findDisconnectedID returns the disconnected client id by user id.
 func (h *Hub) findDisconnectedID(userID string) string {
+	var latest *Client
+
 	for _, c := range h.Disconnectors {
-		if c.UserID == userID {
-			return c.ID
+		if c.UserID == userID && isNewerClient(c, latest) {
+			latest = c
 		}
 	}
 
-	return ""
+	if latest == nil {
+		return ""
+	}
+
+	return latest.ID
+}
+
+func (h *Hub) findActiveID(userID string, role string, markNo int) string {
+	var latest *Client
+
+	for _, c := range h.Clients {
+		if !matchesActiveIdentity(c, userID, role, markNo) {
+			continue
+		}
+
+		if isNewerClient(c, latest) {
+			latest = c
+		}
+	}
+
+	if latest == nil {
+		return ""
+	}
+
+	return latest.ID
+}
+
+func matchesActiveIdentity(c *Client, userID string, role string, markNo int) bool {
+	if c.Role != role {
+		return false
+	}
+
+	switch role {
+	case AthleteRole, ManagerRole:
+		return c.UserID == userID
+	case MarkRole:
+		return c.MarkNo == markNo || c.UserID == userID
+	default:
+		return false
+	}
 }

--- a/v4/ws/racing/logger.go
+++ b/v4/ws/racing/logger.go
@@ -2,6 +2,7 @@ package racing
 
 import (
 	"context"
+	"errors"
 	"os"
 	"time"
 
@@ -12,6 +13,8 @@ import (
 
 const (
 	gcpProjectID = "bsam-app"
+	// #nosec G101 -- This is a local fallback path for development only.
+	localCredentialPath = "./bsam-app-d23e7e5025e7.json"
 )
 
 type BigQueryLogger struct {
@@ -33,27 +36,36 @@ type LocationLogsDAO struct {
 func NewBigQueryLogger() *BigQueryLogger {
 	ctx := context.Background()
 
-	var client *bigquery.Client
-
-	if _, err := os.Stat("./bsam-app-d23e7e5025e7.json"); !os.IsNotExist(err) {
-		// 認証ファイルがあるときは認証ファイルを使用 (GCP環境ではないとき)
-		auth := option.WithCredentialsFile("./bsam-app-d23e7e5025e7.json")
-		client, err = bigquery.NewClient(ctx, gcpProjectID, auth)
-
-		if err != nil {
-			panic(err)
-		}
-	} else {
-		client, err = bigquery.NewClient(ctx, gcpProjectID)
-
-		if err != nil {
-			panic(err)
-		}
+	client, err := newBigQueryClient(ctx)
+	if err != nil {
+		panic(err)
 	}
 
 	return &BigQueryLogger{
 		Client: client,
 	}
+}
+
+func newBigQueryClient(ctx context.Context) (*bigquery.Client, error) {
+	credentialPath := localCredentialPath
+	if envCredentialPath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); envCredentialPath != "" {
+		credentialPath = envCredentialPath
+	}
+
+	// #nosec G703 -- Credential files are intentionally sourced from ADC env or the local dev fallback.
+	_, err := os.Stat(credentialPath)
+	if err == nil {
+		// 認証ファイルがあるときは認証ファイルを使用 (GCP環境ではないとき)
+		auth := option.WithAuthCredentialsFile(option.ServiceAccount, credentialPath)
+
+		return bigquery.NewClient(ctx, gcpProjectID, auth)
+	}
+
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	return bigquery.NewClient(ctx, gcpProjectID)
 }
 
 func (l *BigQueryLogger) logLocation(c *Client) error {
@@ -82,7 +94,9 @@ func (l *BigQueryLogger) logLocation(c *Client) error {
 	}
 
 	inserter := tableRef.Inserter()
-	if err := inserter.Put(context.Background(), data); err != nil {
+
+	err := inserter.Put(context.Background(), data)
+	if err != nil {
 		return err
 	}
 

--- a/v4/ws/racing/racing_test.go
+++ b/v4/ws/racing/racing_test.go
@@ -1,0 +1,266 @@
+//nolint:testpackage // These tests validate internal session-dedup behavior directly.
+package racing
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	testAthleteUserID = "athlete1"
+	testMarkUserID    = "mark1"
+	testJWTSecret     = "test-secret"
+)
+
+func TestMain(m *testing.M) {
+	_ = os.Setenv("JWT_SECRET", testJWTSecret)
+
+	os.Exit(m.Run())
+}
+
+func TestAuthReplacesActiveAthleteSession(t *testing.T) {
+	t.Parallel()
+
+	hub := newTestHub()
+	token := newTestToken(t)
+
+	oldClient := newTestClient(hub, "athlete-old")
+	oldClient.UserID = testAthleteUserID
+	oldClient.Role = AthleteRole
+	oldClient.NextMarkNo = 3
+	oldClient.CourseLimit = 12.5
+	oldClient.BatteryLevel = 66
+	oldClient.Location = Location{Lat: 34.0, Lng: 136.0, Acc: 2.5}
+	oldClient.ConnectedAt = time.Now().Add(-time.Minute)
+	hub.Clients[oldClient.ID] = oldClient
+	hub.Athletes[oldClient.ID] = oldClient
+
+	newClient := newTestClient(hub, "athlete-new")
+	hub.Clients[newClient.ID] = newClient
+
+	newClient.auth(&AuthInfo{
+		Token:  token,
+		UserID: testAthleteUserID,
+		Role:   AthleteRole,
+	})
+	drainHubLifecycle(hub)
+
+	if hub.Athletes[newClient.ID] == nil {
+		t.Fatalf("expected new athlete session to be registered")
+	}
+
+	if _, exists := hub.Clients[oldClient.ID]; exists {
+		t.Fatalf("expected old athlete session to be removed")
+	}
+
+	if newClient.NextMarkNo != 3 {
+		t.Fatalf("expected next mark number to be restored, got %d", newClient.NextMarkNo)
+	}
+}
+
+func TestAuthReplacesActiveMarkSession(t *testing.T) {
+	t.Parallel()
+
+	hub := newTestHub()
+	token := newTestToken(t)
+
+	oldClient := newTestClient(hub, "mark-old")
+	oldClient.UserID = testMarkUserID
+	oldClient.Role = MarkRole
+	oldClient.MarkNo = 1
+	oldClient.BatteryLevel = 90
+	oldClient.Location = Location{
+		Lat:            34.0,
+		Lng:            136.0,
+		Acc:            0.0,
+		PositionSource: PositionSourceManual,
+	}
+	oldClient.ConnectedAt = time.Now().Add(-time.Minute)
+	hub.Clients[oldClient.ID] = oldClient
+	hub.Marks[oldClient.ID] = oldClient
+
+	newClient := newTestClient(hub, "mark-new")
+	hub.Clients[newClient.ID] = newClient
+
+	newClient.auth(&AuthInfo{
+		Token:  token,
+		UserID: testMarkUserID,
+		Role:   MarkRole,
+		MarkNo: 1,
+	})
+	drainHubLifecycle(hub)
+
+	if hub.Marks[newClient.ID] == nil {
+		t.Fatalf("expected new mark session to be registered")
+	}
+
+	if _, exists := hub.Clients[oldClient.ID]; exists {
+		t.Fatalf("expected old mark session to be removed")
+	}
+
+	if newClient.MarkNo != 1 {
+		t.Fatalf("expected mark number to be restored, got %d", newClient.MarkNo)
+	}
+
+	if newClient.Location.PositionSource != PositionSourceManual {
+		t.Fatalf("expected position source to be carried over, got %q", newClient.Location.PositionSource)
+	}
+}
+
+func TestGenerateLiveMsgChoosesNewestDuplicateSessions(t *testing.T) {
+	t.Parallel()
+
+	hub := newTestHub()
+	older := time.Now().Add(-time.Minute)
+	newer := time.Now()
+
+	oldAthlete := newTestClient(hub, "athlete-old")
+	oldAthlete.UserID = testAthleteUserID
+	oldAthlete.Role = AthleteRole
+	oldAthlete.NextMarkNo = 1
+	oldAthlete.ConnectedAt = older
+	hub.Athletes[oldAthlete.ID] = oldAthlete
+
+	newAthlete := newTestClient(hub, "athlete-new")
+	newAthlete.UserID = testAthleteUserID
+	newAthlete.Role = AthleteRole
+	newAthlete.NextMarkNo = 2
+	newAthlete.ConnectedAt = newer
+	hub.Athletes[newAthlete.ID] = newAthlete
+
+	oldMark := newTestClient(hub, "mark-old")
+	oldMark.UserID = testMarkUserID
+	oldMark.Role = MarkRole
+	oldMark.MarkNo = 1
+	oldMark.ConnectedAt = older
+	oldMark.Location = Location{Acc: 2.0, PositionSource: PositionSourceGPS}
+	hub.Marks[oldMark.ID] = oldMark
+
+	newMark := newTestClient(hub, "mark-new")
+	newMark.UserID = testMarkUserID
+	newMark.Role = MarkRole
+	newMark.MarkNo = 1
+	newMark.ConnectedAt = newer
+	newMark.Location = Location{Acc: 0.0, PositionSource: PositionSourceManual}
+	hub.Marks[newMark.ID] = newMark
+
+	msg := hub.generateLiveMsg()
+
+	if len(msg.Athletes) != 1 {
+		t.Fatalf("expected one deduplicated athlete, got %d", len(msg.Athletes))
+	}
+
+	if msg.Athletes[0].NextMarkNo != 2 {
+		t.Fatalf("expected newest athlete state, got %d", msg.Athletes[0].NextMarkNo)
+	}
+
+	if msg.Marks[0].Position.PositionSource != PositionSourceManual {
+		t.Fatalf("expected newest mark state, got %q", msg.Marks[0].Position.PositionSource)
+	}
+}
+
+func TestInsertTypeToJSONIncludesPositionSource(t *testing.T) {
+	t.Parallel()
+
+	payload := insertTypeToJSON(&MarkPosMsg{
+		MarkNum: 1,
+		Marks: []Mark{
+			{
+				MarkNo: 1,
+				Position: Position{
+					Lat:            34.0,
+					Lng:            136.0,
+					Acc:            0.0,
+					PositionSource: PositionSourceManual,
+				},
+			},
+		},
+	}, "mark_position")
+
+	var decoded map[string]any
+
+	err := json.Unmarshal(payload, &decoded)
+	if err != nil {
+		t.Fatalf("failed to decode payload: %v", err)
+	}
+
+	marks, ok := decoded["marks"].([]any)
+	if !ok {
+		t.Fatalf("expected marks to be []any, got %T", decoded["marks"])
+	}
+
+	firstMark, ok := marks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected first mark to be map[string]any, got %T", marks[0])
+	}
+
+	position, ok := firstMark["position"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected position to be map[string]any, got %T", firstMark["position"])
+	}
+
+	if position["position_source"] != PositionSourceManual {
+		t.Fatalf("expected position_source to be serialized, got %#v", position["position_source"])
+	}
+}
+
+func newTestHub() *Hub {
+	return &Hub{
+		AssociationID: "assoc",
+		Clients:       make(map[string]*Client),
+		Athletes:      make(map[string]*Client),
+		Marks:         make(map[string]*Client),
+		Managers:      make(map[string]*Client),
+		Disconnectors: make(map[string]*Client),
+		MarkNum:       MarkNum,
+		Register:      make(chan *Client, 10),
+		Disconnect:    make(chan *Client, 10),
+		Unregister:    make(chan *Client, 10),
+	}
+}
+
+func newTestClient(hub *Hub, id string) *Client {
+	return &Client{
+		ID:           id,
+		ConnectedAt:  time.Now(),
+		Hub:          hub,
+		MarkNo:       -1,
+		NextMarkNo:   1,
+		Location:     Location{},
+		BatteryLevel: -1,
+		Send:         make(chan []byte, 10),
+	}
+}
+
+func drainHubLifecycle(hub *Hub) {
+	for {
+		select {
+		case client := <-hub.Unregister:
+			hub.unregisterEvent(client)
+		case client := <-hub.Disconnect:
+			hub.disconnectEvent(client)
+		default:
+			return
+		}
+	}
+}
+
+func newTestToken(t *testing.T) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "tester",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	signedToken, err := token.SignedString([]byte(testJWTSecret))
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	return signedToken
+}

--- a/v4/ws/racing/read.go
+++ b/v4/ws/racing/read.go
@@ -40,7 +40,7 @@ type DebugInfo struct {
 
 // TODO: 関数を細かく分ける
 //
-//nolint:funlen,gocognit,cyclop
+//nolint:funlen,cyclop
 func (c *Client) readPump() {
 	c.Conn.SetReadLimit(MaxMessageByte)
 
@@ -68,7 +68,9 @@ func (c *Client) readPump() {
 		}
 
 		var msg map[string]any
-		if err := json.Unmarshal(msgRaw, &msg); err != nil {
+
+		err = json.Unmarshal(msgRaw, &msg)
+		if err != nil {
 			log.Println(err)
 			continue
 		}
@@ -87,92 +89,118 @@ func (c *Client) readPump() {
 		// Call handler by message type
 		switch msgType {
 		case "auth":
-			var msg AuthInfo
-
-			err := json.Unmarshal(msgRaw, &msg)
-			if err != nil {
-				log.Printf("Error <%s>: %s\n", c.UserID, err)
-				continue
-			}
-
-			c.auth(&msg)
+			c.handleAuthMessage(msgRaw)
 
 		case "position":
-			var msg Position
-
-			err := json.Unmarshal(msgRaw, &msg)
-			if err != nil {
-				log.Printf("Error <%s>: %s\n", c.UserID, err)
-				continue
-			}
-
-			c.receivePos(&msg)
+			c.handlePositionMessage(msgRaw)
 
 		case "location":
-			var msg Location
-
-			err := json.Unmarshal(msgRaw, &msg)
-			if err != nil {
-				log.Printf("Error <%s>: %s\n", c.UserID, err)
-				continue
-			}
-
-			c.receiveLoc(&msg)
+			c.handleLocationMessage(msgRaw)
 
 		case "passed":
-			var msg PassedInfo
-
-			err := json.Unmarshal(msgRaw, &msg)
-			if err != nil {
-				log.Printf("Error <%s>: %s\n", c.UserID, err)
-				continue
-			}
-
-			c.handlerPassed(&msg)
+			c.handlePassedMessage(msgRaw)
 
 		case "start":
-			var msg StartInfo
-
-			err := json.Unmarshal(msgRaw, &msg)
-			if err != nil {
-				log.Printf("Error <%s>: %s\n", c.UserID, err)
-				continue
-			}
-
-			c.Hub.startRace(msg.IsStarted)
+			c.handleStartMessage(msgRaw)
 
 		case "set_next_mark_no":
-			var msg SetMarkNoInfo
-
-			err := json.Unmarshal(msgRaw, &msg)
-			if err != nil {
-				log.Printf("Error <%s>: %s\n", c.UserID, err)
-				continue
-			}
-
-			c.Hub.setNextMarkNoForce(&msg)
+			c.handleSetNextMarkNoMessage(msgRaw)
 
 		case "battery":
-			var msg BatteryInfo
-
-			err := json.Unmarshal(msgRaw, &msg)
-			if err != nil {
-				log.Printf("Error <%s>: %s\n", c.UserID, err)
-				continue
-			}
-
-			c.receiveBattery(&msg)
+			c.handleBatteryMessage(msgRaw)
 
 		case "debug":
-			var msg DebugInfo
-
-			err := json.Unmarshal(msgRaw, &msg)
-			if err != nil {
-				log.Printf("Error <%s>: %s\n", c.UserID, err)
-				continue
-			}
-
-			log.Printf("Debug <%s>: %s\n", c.UserID, msg.Message)
+			c.handleDebugMessage(msgRaw)
 		}
 	}
+}
+
+func (c *Client) handleAuthMessage(msgRaw []byte) {
+	var msg AuthInfo
+
+	if !c.decodeMessage(msgRaw, &msg) {
+		return
+	}
+
+	c.auth(&msg)
+}
+
+func (c *Client) handlePositionMessage(msgRaw []byte) {
+	var msg Position
+
+	if !c.decodeMessage(msgRaw, &msg) {
+		return
+	}
+
+	c.receivePos(&msg)
+}
+
+func (c *Client) handleLocationMessage(msgRaw []byte) {
+	var msg Location
+
+	if !c.decodeMessage(msgRaw, &msg) {
+		return
+	}
+
+	c.receiveLoc(&msg)
+}
+
+func (c *Client) handlePassedMessage(msgRaw []byte) {
+	var msg PassedInfo
+
+	if !c.decodeMessage(msgRaw, &msg) {
+		return
+	}
+
+	c.handlerPassed(&msg)
+}
+
+func (c *Client) handleStartMessage(msgRaw []byte) {
+	var msg StartInfo
+
+	if !c.decodeMessage(msgRaw, &msg) {
+		return
+	}
+
+	c.Hub.startRace(msg.IsStarted)
+}
+
+func (c *Client) handleSetNextMarkNoMessage(msgRaw []byte) {
+	var msg SetMarkNoInfo
+
+	if !c.decodeMessage(msgRaw, &msg) {
+		return
+	}
+
+	c.Hub.setNextMarkNoForce(&msg)
+}
+
+func (c *Client) handleBatteryMessage(msgRaw []byte) {
+	var msg BatteryInfo
+
+	if !c.decodeMessage(msgRaw, &msg) {
+		return
+	}
+
+	c.receiveBattery(&msg)
+}
+
+func (c *Client) handleDebugMessage(msgRaw []byte) {
+	var msg DebugInfo
+
+	if !c.decodeMessage(msgRaw, &msg) {
+		return
+	}
+
+	log.Printf("Debug <%s>: %s\n", c.UserID, msg.Message)
+}
+
+func (c *Client) decodeMessage(msgRaw []byte, target any) bool {
+	err := json.Unmarshal(msgRaw, target)
+	if err != nil {
+		log.Printf("Error <%s>: %s\n", c.UserID, err)
+		return false
+	}
+
+	return true
 }

--- a/v4/ws/racing/write.go
+++ b/v4/ws/racing/write.go
@@ -173,6 +173,7 @@ func (c *Client) writePump() {
 			err := c.sendEvent(msg, ok)
 			if err != nil {
 				log.Printf("%s (%s) >> write pump error: %v\n", c.ID, c.UserID, err)
+
 				c.Hub.Disconnect <- c
 
 				return
@@ -195,6 +196,7 @@ func (c *Client) writePump() {
 			err := c.pingEvent()
 			if err != nil {
 				log.Printf("%s (%s) >> ping error: %v\n", c.ID, c.UserID, err)
+
 				c.Hub.Disconnect <- c
 
 				return


### PR DESCRIPTION
## 概要
再接続時に同一ユーザーのセッションが一時的に重複する問題を修正し、
mark position payload に `position_source` を追加しました。

## 変更内容
- 同一 user / mark の active session が存在する場合は新しい接続へ置き換え
- live message 生成時は重複があっても最新接続を優先
- mark position payload に `position_source` を追加
- WebSocket / mark payload 周辺のテストを追加
- logger / readPump 周辺を lint に沿って整理

## 背景
選手端末の再接続時に同じ選手情報が一時的に重複し、
本部画面で案内対象マークが不安定に見える原因になっていました。
あわせて、manual 判定が `accuracy == 0` に依存していたため、
意味の衝突を避けるために専用プロパティへ分離しています。

## 確認
- `go test ./v4/ws/racing`
- `golangci-lint run ./v4/ws/racing/...`
